### PR TITLE
Added Response classes to return status codes different from 200

### DIFF
--- a/api_factory/exceptions.py
+++ b/api_factory/exceptions.py
@@ -45,3 +45,7 @@ class InvalidValueError(ClientError):
 class AuthenticationError(ClientError):
     def __str__(self):
         return 'authentication error'
+
+
+class Http404(Exception):
+    pass

--- a/api_factory/responses.py
+++ b/api_factory/responses.py
@@ -1,0 +1,41 @@
+import json
+
+
+class Response:
+    def __init__(self, data_json, *, status_code=200, is_binary=False, headers=None, encoder_class=None):
+        self.headers = headers or {}
+        self.data_json = data_json
+        self.status_code = status_code
+        self.is_binary = is_binary
+        self.encoder_class = encoder_class
+
+    @property
+    def data(self):
+        return json.dumps(self.data_json, cls=self.encoder_class)
+
+    def to_aws_response(self):
+        return {
+            'isBase64Encoded': self.is_binary,
+            'statusCode': self.status_code,
+            'headers': self.headers,
+            'body': self.data,
+        }
+
+
+class Http200Response(Response):
+    status_code = 200
+
+    def __init__(self, data_json, *, is_binary=False, headers=None, encoder_class=None):
+        super(Http200Response, self).__init__(data_json, status_code=self.status_code, is_binary=is_binary,
+                                              headers=headers, encoder_class=encoder_class)
+
+
+class Http404Response(Response):
+    status_code = 404
+
+    def __init__(self, error_message, *, headers=None, encoder_class=None):
+        data_json = {
+            'message': error_message,
+        }
+        super(Http404Response, self).__init__(data_json, status_code=self.status_code, is_binary=False,
+                                              headers=headers, encoder_class=encoder_class)

--- a/api_factory/tests/test_auto_docs.py
+++ b/api_factory/tests/test_auto_docs.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
 
-from ..handlers import BaseHandler
-from ..forms import BaseInputForm, BaseOutputForm
-from ..fields import StringField, BooleanField, ListField, SubformField
-from ..auto_docs import collect_documentation
+from api_factory.handlers import BaseHandler
+from api_factory.forms import BaseInputForm, BaseOutputForm
+from api_factory.fields import StringField, BooleanField, ListField, SubformField
+from api_factory.auto_docs import collect_documentation
 
 
 class TestAutoDocs(TestCase):

--- a/api_factory/tests/test_fields.py
+++ b/api_factory/tests/test_fields.py
@@ -1,7 +1,7 @@
 import unittest
 
-from ..fields import StringField, FloatField, IntegerField, ListField, BooleanField, DictField
-from ..exceptions import FieldValidationError
+from api_factory.fields import StringField, FloatField, IntegerField, ListField, BooleanField, DictField
+from api_factory.exceptions import FieldValidationError
 
 
 class TestFields(unittest.TestCase):

--- a/api_factory/tests/test_forms.py
+++ b/api_factory/tests/test_forms.py
@@ -1,8 +1,8 @@
 import unittest
 
-from ..forms import BaseInputForm, BaseOutputForm
-from ..fields import StringField, IntegerField, SubformField, DictSubformField, ListSubformField
-from ..exceptions import RequiredFieldError, InvalidValueError, ServerError
+from api_factory.forms import BaseInputForm, BaseOutputForm
+from api_factory.fields import StringField, IntegerField, SubformField, DictSubformField, ListSubformField
+from api_factory.exceptions import RequiredFieldError, InvalidValueError, ServerError
 
 
 class TestInputForms(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="api_factory",
-    version="0.1.12",
+    version="0.1.13",
     author="SmartXpo Solutions Limited",
     author_email="info@smartxpo.com",
     description="",


### PR DESCRIPTION
The old API will still work as it works before, e.g. return HTTP 200 OK for any response.

For new API we now have an ability to return a different from HTTP 200 response, for example 404, 401, etc